### PR TITLE
fix typos in open source camp event

### DIFF
--- a/pages/events/2021-12-cyberland-open-source-camp.md
+++ b/pages/events/2021-12-cyberland-open-source-camp.md
@@ -35,7 +35,7 @@ Ort: Hauptbühne in Workadventure
 
 17:30 - 20:00 (Open End) Hacken an den Open Source Projekten
 
-JUnit5 (Christian Stein), Maven (Karl Heinz Marbaise), Testcontainers (Kevin Wittek), Asciidoc IntelliJ Plugin (Alexander Schwarz), DocToolChain (Ralf Müller), jQAssistant (Dirk Mahler)
+JUnit5 (Christian Stein), Maven (Karl Heinz Marbaise), Testcontainers (Kevin Wittek), AsciiDoc IntelliJ Plugin (Alexander Schwartz), DocToolChain (Ralf Müller), jQAssistant (Dirk Mahler)
 
 Orte (Bereiche in Workadventure):
 * im Raum "log park"


### PR DESCRIPTION
Fixing two small typos.