### PR TITLE
Bild-Vorschau auf Twitter und Textzusammenfassung

### DIFF
--- a/_includes/default/html-head.html
+++ b/_includes/default/html-head.html
@@ -3,11 +3,6 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta property="twitter:site" content="@CyberLandConf" />
-  {%- if page.featuredImage -%}
-    <meta property="og:image" content="{{ site.url }}/assets/featuredImages/{{ page.featuredImage }}.png" />
-  {%- else -%}
-    <meta property="og:image" content="{{ site.url }}/assets/featuredImages/default.png" />
-  {%- endif -%}
   {%- seo -%}
   <link rel="stylesheet" href="/assets/css/styles.css">
   <link rel="manifest" href="/manifest.json">

--- a/pages/events/2021-12-cyberland-open-source-camp.md
+++ b/pages/events/2021-12-cyberland-open-source-camp.md
@@ -6,7 +6,9 @@ permalink: /2021-12-open-source-camp/
 order: 12
 hidden: true
 meetupId: cyberland-open-source-camp-advent-punsh
+description: Wir laden zum zweiten Code Camp Event ein. Wir treffen uns, um zusammen etwas zu Open-Source-Projekten beizusteuern.
 limit: 50
+image: /assets/logo/cyberland_Os_camp_christmas.jpg
 hideVideoRecording: true
 ---
 


### PR DESCRIPTION
Mit fiel auf, dass die Twitter-Card keine Zusammenfassung und kein Bild enthält: 

![image](https://user-images.githubusercontent.com/3957921/146077544-3243daee-f18c-44ac-8760-4a5837874f32.png)

Dieser PR sollte das für diesen Post nachholen. `featuredImage` wird entfernt, das es nicht verwendet wird, und schon vom Jekyll-SEO-Modul von `image` bereitgestellt wird, vgl. https://github.com/jekyll/jekyll-seo-tag/blob/master/docs/usage.md

> The SEO tag will respect the following YAML front matter if included in a post, page, or document:
title - The title of the post, page, or document
description - A short description of the page's content
image - URL to an image associated with the post, page, or document (e.g., /assets/page-pic.jpg)
author - Page-, post-, or document-specific author information (see Advanced usage)
locale - Page-, post-, or document-specific locale information. Takes priority over existing front matter attribute lang.
Note: Front matter defaults can be used for any of the above values as described in advanced usage with an image example.

Sobald die Änderung live ist kann die Karte mit https://cards-dev.twitter.com/validator überprüft werden.

Damit dies auch bei zukünftigen Blogposts funktioniert, sollte `image` und `description` im Frontmatter von zukünftigen Blog-Posts gesetzt werden.