### PR TITLE
Add Calendar link to navigation

### DIFF
--- a/_includes/default/navigation.html
+++ b/_includes/default/navigation.html
@@ -32,6 +32,7 @@
           <span class="icon is-medium"><a class="navbar-item icon-navbar-item" title="Mastodon" href="https://ijug.social/@CyberlandConf"><i class="fab fa-lg fa-mastodon"></i></a></span>
           <span class="icon is-medium"><a class="navbar-item icon-navbar-item" title="GitHub" href="https://github.com/cyberlandconf/cyberlandconf.github.io"><i class="fab fa-lg fa-github"></i></a></span>
           <span class="icon is-medium"><a class="navbar-item icon-navbar-item" title="YouTube" href="https://www.youtube.com/channel/UCAMGr2FLBzpxnVJCk-Lhd_A"><i class="fab fa-lg fa-youtube"></i></a></span>
+          <span class="icon is-medium"><a class="navbar-item icon-navbar-item" title="Calendar of Events" href="{{ "/events.ics" | relative_url }}"><i class="fab fa-lg fa-calendar"></i></a></span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
If there is already a calendar. The site should link to it.